### PR TITLE
Remove round from `pmt` and `fv` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 To use Exonio you just have to call the method you like to use. Example:
 
 ```ruby
- Exonio.pmt(0.075 / 12, 12 * 15, 200_000) # ==> -1854.02
+ Exonio.pmt(0.075 / 12, 12 * 15, 200_000) # ==> -1854.0247200054619
 ```
 
 ## Available Formulas
@@ -36,7 +36,7 @@ an additional monthly savings of $100 with the interest rate at
 5% (annually) compounded monthly?
 
 ```ruby
-Exonio.fv(0.05 / 12, 10 * 12, -100, -100) # ==> 15692.93
+Exonio.fv(0.05 / 12, 10 * 12, -100, -100) # ==> 15692.928894335748
 ```
 
 By convention, the negative sign represents cash flow out (i.e. money not
@@ -60,7 +60,7 @@ What is the monthly payment needed to pay off a $200,000 loan in 15
 years at an annual interest rate of 7.5%?
 
 ```ruby
-Exonio.nper(0.075 / 12, 12 * 15, 200_000) # ==> -1854.02
+Exonio.pmt(0.075 / 12, 12 * 15, 200_000) # ==> -1854.0247200054619
 ```
 
 In order to pay-off (i.e., have a future-value of 0) the $200,000 obtained

--- a/exonio.gemspec
+++ b/exonio.gemspec
@@ -13,14 +13,6 @@ Gem::Specification.new do |spec|
   spec.description   = %q{This gem implements some useful Excel formulas like PMT, IPMT, NPER, PV, etc...}
   spec.homepage      = "http://github.com/noverde/exonio"
 
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/lib/exonio/financial.rb
+++ b/lib/exonio/financial.rb
@@ -13,14 +13,13 @@ module Exonio
     # @return [Float]
     #
     # @example
-    #   Exonio.fv(0.05 / 12, 12 * 10, -100, -100) # ==> 15692.93
+    #   Exonio.fv(0.05 / 12, 12 * 10, -100, -100) # ==> 15692.928894335748
     #
     def fv(rate, nper, pmt, pv, end_or_beginning = 0)
       temp = (1 + rate) ** nper
       fact = (1 + rate* end_or_beginning) * (temp - 1) / rate
-      result = -(pv * temp + pmt * fact)
 
-      result.round(2)
+      -(pv * temp + pmt * fact)
     end
 
 
@@ -59,14 +58,13 @@ module Exonio
     # @return [Float]
     #
     # @example
-    #   Exonio.pmt(0.075/12, 12*15, 200_000) # ==> -1854.02
+    #   Exonio.pmt(0.075/12, 12*15, 200_000) # ==> -1854.0247200054619
     #
     def pmt(rate, nper, pv, fv = 0, end_or_beginning = 0)
       temp = (1 + rate) ** nper
       fact = (1 + rate * end_or_beginning) * (temp - 1) / rate
-      result = -(fv + pv * temp) / fact
 
-      result.round(2)
+      -(fv + pv * temp) / fact
     end
   end
 end

--- a/spec/financial_spec.rb
+++ b/spec/financial_spec.rb
@@ -10,13 +10,13 @@ describe Exonio::Financial do
     it 'computes fv with default arguments' do
       results = Exonio.fv(rate, nper, pmt, pv)
 
-      expect(results).to eq(15692.93)
+      expect(results).to eq(15692.928894335748)
     end
 
     it 'computes fv when payments are due at beginning' do
       results = Exonio.fv(rate, nper, pmt, pv, 1)
 
-      expect(results).to eq(15757.63)
+      expect(results).to eq(15757.629844104778)
     end
   end
 
@@ -60,25 +60,25 @@ describe Exonio::Financial do
     it 'computes pmt with default arguments' do
       results = Exonio.pmt(rate, nper, pv)
 
-      expect(results).to eq(-1854.02)
+      expect(results).to eq(-1854.0247200054619)
     end
 
     it 'computes pmt with fv argument' do
       results = Exonio.pmt(rate, nper, pv, fv)
 
-      expect(results).to eq(-1884.23)
+      expect(results).to eq(-1884.225956005735)
     end
 
     it 'computes pmt when payments are due at beginning' do
       results = Exonio.pmt(rate, nper, pv, 0, 1)
 
-      expect(results).to eq(-1842.51)
+      expect(results).to eq(-1842.5090385147448)
     end
 
     it 'computes pmt with fv and due at beginning' do
       results = Exonio.pmt(rate, nper, pv, fv, 1)
 
-      expect(results).to eq(-1872.52)
+      expect(results).to eq(-1872.522689198246)
     end
   end
 end


### PR DESCRIPTION
This PR removes the `round` from `pmt` and `fv` methods.