### PR TITLE
fix infinite loop with bigscale on RATE method

### DIFF
--- a/lib/exonio/financial.rb
+++ b/lib/exonio/financial.rb
@@ -135,7 +135,7 @@ module Exonio
 
       begin
         temp = newton_iter(guess, nper, pmt, pv, fv, end_or_beginning)
-        next_guess = guess - temp
+        next_guess = (guess - temp).round(20)
         diff = (next_guess - guess).abs
         close = diff < tolerancy
         guess = next_guess

--- a/spec/financial_spec.rb
+++ b/spec/financial_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'bigdecimal'
 
 describe Exonio::Financial do
   describe '#fv' do
@@ -165,6 +166,17 @@ describe Exonio::Financial do
       results = Exonio.rate(nper, pmt, pv, 0, 1)
 
       expect(results).to eq(0.07265012823626603)
+    end
+
+    context 'with large decimal scale' do
+      let(:pmt) { BigDecimal.new("351.622169863986539264256777349669281495") }
+      let(:pv) { BigDecimal.new("-3061.762000011") }
+
+      it 'computes rate' do
+        results = Exonio.rate(nper, pmt, pv) * 100
+
+        expect(results.round(2)).to eq(5.32)
+      end
     end
   end
 end


### PR DESCRIPTION
Before this PR, when the scale value of PMT were TOO BIG, the `newton_iter` was veeeeeeery slow to iterate, causing an infinite loop.

This PR fix it.