### PR TITLE
Fix IRR method

### DIFF
--- a/lib/exonio/financial.rb
+++ b/lib/exonio/financial.rb
@@ -178,7 +178,7 @@ module Exonio
     #
     def irr(values)
       func = Helpers::IrrHelper.new(values)
-      guess = [ func.zero ]
+      guess = [ func.eps ]
       nlsolve( func, guess)
       guess[0]
     end

--- a/spec/financial_spec.rb
+++ b/spec/financial_spec.rb
@@ -182,9 +182,9 @@ describe Exonio::Financial do
 
   describe '#npv' do
     it 'computes the net present value' do
-      results = Exonio.npv(0.281, [-100.0, 39, 59, 55, 20])
+      results = Exonio.npv(0.281, CashflowFixture.cashflows)
 
-      expect(results).to eq(-0.00661872883563408)
+      expect(results).to eq(-7787.382638079077)
     end
 
     context 'with large cashflows' do
@@ -196,9 +196,9 @@ describe Exonio::Financial do
 
   describe '#irr' do
     it 'computes the internal rate of return' do
-      results = Exonio.irr([-100, 39, 59, 55, 20])
+      results = Exonio.irr(CashflowFixture.cashflows)
 
-      expect(results.round(5)).to eq(0.28095)
+      expect(results.round(5)).to eq(0.00146)
     end
   end
 end


### PR DESCRIPTION
This PR fix the `irr` method, which in some cases was generating weird large numbers. 
The reason relies on the initial guess, which was ZERO, now it is EPS.

The `npv` and `irr` specs were updated too, to reflect a more realistic scenario.