### PR TITLE
Fix nper documentation

### DIFF
--- a/lib/exonio/financial.rb
+++ b/lib/exonio/financial.rb
@@ -50,14 +50,14 @@ module Exonio
     # constant-amount periodic payments and a constant interest rate.
     #
     # @param rate [Float] The interest rate as decimal (not per cent) per period
-    # @param pmt [Float] The number of payments to be made
-    # @param pv [Float] The present value
+    # @param pmt [Float] The payment amount made each period
+    # @param pv [Float] The present value of the payments
     # @param fv [Float] The future value remaining after the final payment has been made
     # @param end_or_begining [Integer] Whether payments are due at the end (0) or
     #   beggining (1) of each period
     #
     # @return [Float]
-    #
+    # 
     # @example
     #   Exonio.nper(0.07 / 12, -150, 8000) # ==> 64.07334877066185
     #


### PR DESCRIPTION
Hey guys,

According to [this reference ](https://support.office.com/en-us/article/nper-function-240535b5-6653-4d2d-bfcf-b6a38151d815) the second param (`pmt`) for the `nper` function should be the payment made each period.

Please, take a look. Thanks.