### PR TITLE
Fixes Ruby 2.6 BigDecimal deprecation

### DIFF
--- a/lib/exonio/helpers/irr_helper.rb
+++ b/lib/exonio/helpers/irr_helper.rb
@@ -11,7 +11,7 @@ module Exonio
 
       values.each do |key, value|
         define_method key do
-          BigDecimal.new(value)
+          BigDecimal(value)
         end
       end
 

--- a/spec/financial_spec.rb
+++ b/spec/financial_spec.rb
@@ -169,8 +169,8 @@ describe Exonio::Financial do
     end
 
     context 'with large decimal scale' do
-      let(:pmt) { BigDecimal.new("351.622169863986539264256777349669281495") }
-      let(:pv) { BigDecimal.new("-3061.762000011") }
+      let(:pmt) { BigDecimal("351.622169863986539264256777349669281495") }
+      let(:pv) { BigDecimal("-3061.762000011") }
 
       it 'computes rate' do
         results = Exonio.rate(nper, pmt, pv) * 100


### PR DESCRIPTION
We recently added exonio to a Ruby 2.6 project, and we're getting hundreds of console line spam messages about the BigDecimal depreciation. This affected a lot of gems, and I think is an easy change.

```
/Users/bbugh/.rvm/gems/ruby-2.6.2/gems/exonio-0.5.3/lib/exonio/helpers/irr_helper.rb:14: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Users/bbugh/.rvm/gems/ruby-2.6.2/gems/exonio-0.5.3/lib/exonio/helpers/irr_helper.rb:14: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Users/bbugh/.rvm/gems/ruby-2.6.2/gems/exonio-0.5.3/lib/exonio/helpers/irr_helper.rb:14: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Users/bbugh/.rvm/gems/ruby-2.6.2/gems/exonio-0.5.3/lib/exonio/helpers/irr_helper.rb:14: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Users/bbugh/.rvm/gems/ruby-2.6.2/gems/exonio-0.5.3/lib/exonio/helpers/irr_helper.rb:14: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Users/bbugh/.rvm/gems/ruby-2.6.2/gems/exonio-0.5.3/lib/exonio/helpers/irr_helper.rb:14: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Users/bbugh/.rvm/gems/ruby-2.6.2/gems/exonio-0.5.3/lib/exonio/helpers/irr_helper.rb:14: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```