### PR TITLE
fix BigDecimal construction

### DIFF
--- a/lib/exonio/helpers/irr_helper.rb
+++ b/lib/exonio/helpers/irr_helper.rb
@@ -11,7 +11,7 @@ module Exonio
 
       values.each do |key, value|
         define_method key do
-          BigDecimal.new(value)
+          BigDecimal(value)
         end
       end
 


### PR DESCRIPTION
Was getting deprecation warnings:

exonio/lib/exonio/helpers/irr_helper.rb:14: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.