### PR TITLE
nper: return the correct number of payments when the interest rate is 0

### DIFF
--- a/lib/exonio/financial.rb
+++ b/lib/exonio/financial.rb
@@ -57,11 +57,13 @@ module Exonio
     #   beggining (1) of each period
     #
     # @return [Float]
-    # 
+    #
     # @example
     #   Exonio.nper(0.07 / 12, -150, 8000) # ==> 64.07334877066185
     #
     def nper(rate, pmt, pv, fv = 0, end_or_beginning = 0)
+      return (-pv - fv) / pmt if rate.zero?
+
       z = pmt * (1 + rate * end_or_beginning) / rate
       temp = Math.log((-fv + z) / (pv + z))
 

--- a/spec/financial_spec.rb
+++ b/spec/financial_spec.rb
@@ -81,6 +81,20 @@ describe Exonio::Financial do
 
       expect(results).to eq(70.14566694692749)
     end
+
+    it 'computes nper when the interest rate is 0' do
+      # number of $100 payments to pay off a $1000 loan in full
+      results = Exonio.nper(0.0, -100.0, 1000.0)
+
+      expect(results).to eq(10)
+    end
+
+    it 'computes nper when the interest rate is 0 with fv' do
+      # number of $100 payments to reduce a $1000 loan to $200
+      results = Exonio.nper(0.0, -100.00, 1000.0, -200.0)
+
+      expect(results).to eq(8)
+    end
   end
 
   describe '#pmt' do


### PR DESCRIPTION
Fixes https://github.com/noverde/exonio/issues/10, where nper returns `NaN` when the interest rate is 0.

This is essentially a port of https://github.com/numpy/numpy-financial/pull/21