### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,15 +8,17 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ["2.3.1", "2.7", "3.0", "3.1"]
+        ruby: ["2.3.1", "2.7", "3.0", "3.1", "3.2"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Remove Gemfile.lock
+        run: rm Gemfile.lock
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/exonio.gemspec
+++ b/exonio.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry-byebug", "~> 3.3.0"


### PR DESCRIPTION
To get this to green I:

1. Added a step to CI to remove the Gemfile.lock, since current bundler versions are not compatible with Ruby 2.3.1, and historical ones are not compatible with Ruby 3.2
2. Removed the `bundler ~> 1.0` development dependency from the gemspec entirely

Runs green.