### PR TITLE
Fix pmt when interest rate is 0

### DIFF
--- a/lib/exonio/financial.rb
+++ b/lib/exonio/financial.rb
@@ -119,6 +119,8 @@ module Exonio
     #   Exonio.pmt(0.075/12, 12*15, 200_000) # ==> -1854.0247200054619
     #
     def pmt(rate, nper, pv, fv = 0, end_or_beginning = 0)
+      return (-pv - fv) / nper if rate.zero?
+
       temp = (1 + rate) ** nper
       fact = (1 + rate * end_or_beginning) * (temp - 1) / rate
 

--- a/spec/financial_spec.rb
+++ b/spec/financial_spec.rb
@@ -148,6 +148,18 @@ describe Exonio::Financial do
 
       expect(results).to eq(-1872.522689198246)
     end
+
+    it 'computes pmt when the interest rate is 0' do
+      results = Exonio.pmt(0.0, 36, 36_000.0)
+
+      expect(results).to eq(-1000.0)
+    end
+
+    it 'computes pmt when the interest rate is 0 with fv' do
+      results = Exonio.pmt(0.0, 24, 24_000.0, -12_000.0)
+
+      expect(results).to eq(-500.0)
+    end
   end
 
   describe '#pv' do


### PR DESCRIPTION
Fixes #10. `pmt` returned `NaN` when passed a rate of `0.0`. 

(#10 was mistakenly closed prematurely)

## BEFORE

```
>> Exonio::VERSION
=> "0.7.0"
>> Exonio.pmt(0.0, 36, 36_000)
=> NaN
```

## AFTER

```
>> Exonio.pmt(0.0, 36, 36_000)
=> -1000
```

