### PR TITLE
chore: bump version from `0.7.0` to `0.7.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.7.1
+
+* Fixed `pmt` when rate is 0.
+
 ## 0.7.0
 
 * Implements `nominal` method (#35)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exonio (0.7.0)
+    exonio (0.7.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/exonio/version.rb
+++ b/lib/exonio/version.rb
@@ -1,3 +1,3 @@
 module Exonio
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
- Updated `CHANGELOG`, `version.rb` and `Gemfile.lock` files referencing the new version.
