### PR TITLE
Bump local dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,40 +6,40 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (8.2.5)
+    byebug (11.1.3)
     coderay (1.1.3)
-    diff-lcs (1.5.0)
-    method_source (1.0.0)
-    pry (0.14.1)
+    diff-lcs (1.5.1)
+    method_source (1.1.0)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.3.0)
-      byebug (~> 8.0)
-      pry (~> 0.10)
-    rake (13.0.6)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.0)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    rake (13.2.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.1)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
 
 PLATFORMS
+  arm64-darwin-23
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.11)
   exonio!
-  pry-byebug (~> 3.3.0)
+  pry-byebug (~> 3.3)
   rake (~> 13.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.2
+   2.5.18


### PR DESCRIPTION
Normally, I would prefer to git-ignore `Gemfile.lock` for a gem, but to stay consistent with the existing codebase, this cleans up the automated dependabot PRs.

- Closes #31 
- Closes #39
- Closes #40 