### PR TITLE
Add ruby 3.4 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
 
     runs-on: ${{ matrix.os }}
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,12 @@ PATH
   remote: .
   specs:
     exonio (0.7.1)
+      bigdecimal
 
 GEM
   remote: https://rubygems.org/
   specs:
+    bigdecimal (3.1.9)
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)

--- a/exonio.gemspec
+++ b/exonio.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency("bigdecimal")
+
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry-byebug", "~> 3.3"


### PR DESCRIPTION
- Add Ruby 3.4 to build matrix
- Add `bigdecimal` as a dependency (no longer part of stdlib)